### PR TITLE
Autoload project classes using the PSR-4 autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "description": "Symfony RAD API Edition for powerful REST applications.",
     "autoload": {
-        "psr-0": { "": "src/" }
+        "psr-4": { "": "src/" }
     },
     "require": {
         "php": ">=5.4",


### PR DESCRIPTION
> Deprecated - As of 2014-10-21 PSR-0 has been marked as deprecated. PSR-4 is now recommended as an alternative. - http://www.php-fig.org/psr/psr-0/

As this is a new project, I thought I might be a good idea to using PSR-4 autoloading instead of the PSR-0 that the Symfony standard edition usually initiates.
